### PR TITLE
Feature: Linking stores and shopping lists

### DIFF
--- a/lib/components/add_new.dart
+++ b/lib/components/add_new.dart
@@ -10,14 +10,12 @@ class AddNew extends StatelessWidget {
   AddNew({Key key, this.listType, this.listID, this.parentList});
 
   goToAddNew(context) async {
-    print(listType);
     if (listType == 'shopping list') {
       Navigator.pushNamed(context, '/newShoppingList');
     } else if (listType == 'store') {
       Navigator.pushNamed(context, '/newStore');
     } else if (listType == 'item') {
       final result = await Navigator.pushNamed(context, '/newItem', arguments: NewItemArguments(parentList.id, parentList.name));
-      print("result: " + result.toString());
     } else {
       print('Error, unhandled listType in goToAddNew in item_list.dart');
     }

--- a/lib/components/linked_entities_list.dart
+++ b/lib/components/linked_entities_list.dart
@@ -30,7 +30,7 @@ class LinkedEntitiesList extends StatelessWidget {
     var shortList = List();
     shortList.add(Text("This $listType is not attached to any $entities yet."));
     // if 'list' is empty, default to shortList which is guaranteed to have something
-    return list?.map((item) => Text(item))?.toList() ?? shortList;
+    return list?.map((item) => Text(item, style: TextStyle(height: 1.6)))?.toList() ?? shortList;
   }
 
   _manageLinksButton() {

--- a/lib/components/linked_entities_list.dart
+++ b/lib/components/linked_entities_list.dart
@@ -11,8 +11,9 @@ class LinkedEntitiesList extends StatelessWidget {
   Widget build(BuildContext context) {
     var _list = linkedEntities != null ? linkedEntities.values.toList() : [];
 
-    return Container(
+    return Flexible(
       child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
           _listTitle(),
           ..._entityList(_list),
@@ -22,13 +23,13 @@ class LinkedEntitiesList extends StatelessWidget {
     }
 
   _listTitle() {
-    return Text("$entities", style: TextStyle(fontSize:20));
+    return Text("$entities", style: TextStyle(fontSize:16, fontWeight: FontWeight.bold));
   }
 
   _entityList(list) {
     var shortList = List();
     shortList.add(Text("This $listType is not attached to any $entities yet."));
-
+    // if 'list' is empty, default to shortList which is guaranteed to have something
     return list?.map((item) => Text(item))?.toList() ?? shortList;
   }
 
@@ -36,6 +37,8 @@ class LinkedEntitiesList extends StatelessWidget {
     return FlatButton(
       onPressed: () => print("pressed"),
       child: Text("Add/Remove $entities"),
+      textColor:Colors.blue,
+      padding: EdgeInsets.all(0),
     );
   }
 }

--- a/lib/components/linked_entities_list.dart
+++ b/lib/components/linked_entities_list.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+class LinkedEntitiesList extends StatelessWidget {
+  final linkedEntities;
+
+  LinkedEntitiesList(this.linkedEntities);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      child: Column(
+        children: linkedEntities.entries.map<Widget>((entry) {
+          var w = Text(entry.value);
+          return w;
+      }).toList()),
+    );
+  }
+}

--- a/lib/components/linked_entities_list.dart
+++ b/lib/components/linked_entities_list.dart
@@ -26,13 +26,10 @@ class LinkedEntitiesList extends StatelessWidget {
   }
 
   _entityList(list) {
-    if (list != null && list.length > 0) {
-      return list.map((item) => Text(item)).toList();
-    } else {
-      var shortList = List();
-      shortList.add(Text("This $listType is not attached to any $entities yet."));
-      return shortList;
-    }
+    var shortList = List();
+    shortList.add(Text("This $listType is not attached to any $entities yet."));
+
+    return list?.map((item) => Text(item))?.toList() ?? shortList;
   }
 
   _manageLinksButton() {

--- a/lib/components/linked_entities_list.dart
+++ b/lib/components/linked_entities_list.dart
@@ -2,17 +2,43 @@ import 'package:flutter/material.dart';
 
 class LinkedEntitiesList extends StatelessWidget {
   final linkedEntities;
+  final String listType;
+  final String entities;
 
-  LinkedEntitiesList(this.linkedEntities);
+  LinkedEntitiesList(this.linkedEntities, this.listType, this.entities);
 
   @override
   Widget build(BuildContext context) {
+    var _list = linkedEntities != null ? linkedEntities.values.toList() : [];
+
     return Container(
       child: Column(
-        children: linkedEntities.entries.map<Widget>((entry) {
-          var w = Text(entry.value);
-          return w;
-      }).toList()),
+        children: <Widget>[
+          _listTitle(),
+          ..._entityList(_list),
+          _manageLinksButton(),
+        ],
+      ));
+    }
+
+  _listTitle() {
+    return Text("$entities", style: TextStyle(fontSize:20));
+  }
+
+  _entityList(list) {
+    if (list != null && list.length > 0) {
+      return list.map((item) => Text(item)).toList();
+    } else {
+      var shortList = List();
+      shortList.add(Text("This $listType is not attached to any $entities yet."));
+      return shortList;
+    }
+  }
+
+  _manageLinksButton() {
+    return FlatButton(
+      onPressed: () => print("pressed"),
+      child: Text("Add/Remove $entities"),
     );
   }
 }

--- a/lib/components/toggle_list.dart
+++ b/lib/components/toggle_list.dart
@@ -5,10 +5,12 @@ import 'package:grocery_go/db/database_manager.dart';
 class LinkedEntity {
   String id;
   String name;
+  String address;
 
   LinkedEntity(DocumentSnapshot document) {
     this.id = document['id'];
     this.name = document['name'];
+    this.address = document['address'] ?? '';
   }
 }
 
@@ -58,7 +60,6 @@ class _ToggleListState extends State<ToggleList> {
       // if we're editing a store, then the parent ID is the store ID and the entity is the shopping list
       db.updateStoreShoppingListLink(entityID, widget.parentID, entityName, widget.parentName, value);
     }
-
   }
 
   @override
@@ -69,9 +70,9 @@ class _ToggleListState extends State<ToggleList> {
         itemCount: widget.list.length,
         itemBuilder: (BuildContext context, int index) {
           var item = LinkedEntity(widget.list[index]);
-
+          var itemName = item.address.length > 0 ? item.name + ' (${item.address})' : item.name;
           return SwitchListTile(
-            title: Text(item.name),
+            title: Text(itemName),
             value: widget.linkedEntities?.containsKey(item.id) ?? false,
             onChanged: (bool value) => toggleItem(item.id, item.name, value),
           );

--- a/lib/components/toggle_list.dart
+++ b/lib/components/toggle_list.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:grocery_go/db/database_manager.dart';
+
+class LinkedEntity {
+  String id;
+  String name;
+
+  LinkedEntity(DocumentSnapshot document) {
+    this.id = document['id'];
+    this.name = document['name'];
+  }
+}
+
+class ToggleList extends StatefulWidget {
+
+  final String parentType;
+  final String parentID;
+  final List list;
+  final Map linkedEntities;
+
+  ToggleList({Key key, @required this.parentType, @required this.parentID, @required this.list, @required this.linkedEntities});
+
+  @override
+  _ToggleListState createState() => _ToggleListState();
+}
+
+class _ToggleListState extends State<ToggleList> {
+
+  final DatabaseManager db = DatabaseManager();
+
+  toggleItem(entityID, val) {
+    print("Changing $entityID to ${val.toString()}");
+    if (widget.parentType == "shoppingList") {
+      db.updateStoreLink(widget.parentID, entityID, val);
+    } else if (widget.parentType == "store") {
+      db.updateShoppingListLink(widget.parentID, entityID, val);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+
+    return ListView.builder(
+        shrinkWrap: true, // gives it a size
+        itemCount: widget.list.length,
+        itemBuilder: (BuildContext context, int index) {
+          var item = LinkedEntity(widget.list[index]);
+
+          return SwitchListTile(
+            title: Text(item.name),
+            value: widget.linkedEntities.containsKey(item.id) ? true : false,
+            onChanged: (bool value) => toggleItem(item.id, value),
+          );
+        }
+    );
+  }
+}
+
+
+

--- a/lib/components/toggle_list.dart
+++ b/lib/components/toggle_list.dart
@@ -30,8 +30,6 @@ class _ToggleListState extends State<ToggleList> {
   final DatabaseManager db = DatabaseManager();
 
   toggleItem(entityID, entityName, value) {
-    print("Toggling " + entityID + " " + value.toString());
-    print(widget.linkedEntities.toString());
 
     if (widget.linkedEntities == null) {
         widget.linkedEntities = Map();
@@ -57,8 +55,6 @@ class _ToggleListState extends State<ToggleList> {
 
   @override
   Widget build(BuildContext context) {
-
-    print(widget.linkedEntities);
 
     return ListView.builder(
         shrinkWrap: true, // gives it a size

--- a/lib/components/toggle_list.dart
+++ b/lib/components/toggle_list.dart
@@ -30,8 +30,8 @@ class _ToggleListState extends State<ToggleList> {
   final DatabaseManager db = DatabaseManager();
 
   toggleItem(entityID, val) {
-    print("Changing $entityID to ${val.toString()}");
-    if (widget.parentType == "shoppingList") {
+    print(widget.parentType);
+    if (widget.parentType == "shopping list") {
       db.updateStoreLink(widget.parentID, entityID, val);
     } else if (widget.parentType == "store") {
       db.updateShoppingListLink(widget.parentID, entityID, val);
@@ -51,7 +51,7 @@ class _ToggleListState extends State<ToggleList> {
 
           return SwitchListTile(
             title: Text(item.name),
-            value: widget.linkedEntities.containsKey(item.id) ? true : false,
+            value: widget.linkedEntities?.containsKey(item.id) ?? false,
             onChanged: (bool value) => toggleItem(item.id, value),
           );
         }

--- a/lib/components/toggle_list.dart
+++ b/lib/components/toggle_list.dart
@@ -16,10 +16,11 @@ class ToggleList extends StatefulWidget {
 
   final String parentType;
   final String parentID;
+  final String parentName;
   final List list;
   Map linkedEntities;
 
-  ToggleList({Key key, @required this.parentType, @required this.parentID, @required this.list, @required this.linkedEntities});
+  ToggleList({Key key, @required this.parentType, @required this.parentID, @required this.parentName, @required this.list, @required this.linkedEntities});
 
   @override
   _ToggleListState createState() => _ToggleListState();
@@ -32,6 +33,7 @@ class _ToggleListState extends State<ToggleList> {
   toggleItem(entityID, entityName, value) {
 
     if (widget.linkedEntities == null) {
+      print("linkedEntities is null");
         widget.linkedEntities = Map();
     }
 
@@ -41,16 +43,22 @@ class _ToggleListState extends State<ToggleList> {
         widget.linkedEntities.remove(entityID);
       });
     } else {
+      print("adding entity");
       setState(() {
         widget.linkedEntities[entityID] = entityName;
       });
     }
+
     // update in database
+    // method params: (shoppingListID, storeID, shoppingListName, storeName, value)
     if (widget.parentType == "shopping list") {
-      db.updateStoreLink(widget.parentID, entityID, entityName, value);
+      // if we're editing a shopping list then the parent ID is the list ID and the entity is the store
+      db.updateStoreShoppingListLink(widget.parentID, entityID, widget.parentName, entityName, value);
     } else if (widget.parentType == "store") {
-      db.updateShoppingListLink(widget.parentID, entityID, entityName, value);
+      // if we're editing a store, then the parent ID is the store ID and the entity is the shopping list
+      db.updateStoreShoppingListLink(entityID, widget.parentID, entityName, widget.parentName, value);
     }
+
   }
 
   @override

--- a/lib/components/toggle_list.dart
+++ b/lib/components/toggle_list.dart
@@ -45,7 +45,6 @@ class _ToggleListState extends State<ToggleList> {
         widget.linkedEntities.remove(entityID);
       });
     } else {
-      print("adding entity");
       setState(() {
         widget.linkedEntities[entityID] = entityName;
       });
@@ -53,6 +52,7 @@ class _ToggleListState extends State<ToggleList> {
 
     // update in database
     // method params: (shoppingListID, storeID, shoppingListName, storeName, value)
+
     if (widget.parentType == "shopping list") {
       // if we're editing a shopping list then the parent ID is the list ID and the entity is the store
       db.updateStoreShoppingListLink(widget.parentID, entityID, widget.parentName, entityName, value);
@@ -74,7 +74,7 @@ class _ToggleListState extends State<ToggleList> {
           return SwitchListTile(
             title: Text(itemName),
             value: widget.linkedEntities?.containsKey(item.id) ?? false,
-            onChanged: (bool value) => toggleItem(item.id, item.name, value),
+            onChanged: (bool value) => toggleItem(item.id, itemName, value),
           );
         }
     );

--- a/lib/components/toggle_list.dart
+++ b/lib/components/toggle_list.dart
@@ -17,7 +17,7 @@ class ToggleList extends StatefulWidget {
   final String parentType;
   final String parentID;
   final List list;
-  final Map linkedEntities;
+  Map linkedEntities;
 
   ToggleList({Key key, @required this.parentType, @required this.parentID, @required this.list, @required this.linkedEntities});
 
@@ -29,12 +29,29 @@ class _ToggleListState extends State<ToggleList> {
 
   final DatabaseManager db = DatabaseManager();
 
-  toggleItem(entityID, val) {
-    print(widget.parentType);
+  toggleItem(entityID, entityName, value) {
+    print("Toggling " + entityID + " " + value.toString());
+    print(widget.linkedEntities.toString());
+
+    if (widget.linkedEntities == null) {
+        widget.linkedEntities = Map();
+    }
+
+    // update "locally"
+    if (widget.linkedEntities.containsKey(entityID)) {
+      setState(() {
+        widget.linkedEntities.remove(entityID);
+      });
+    } else {
+      setState(() {
+        widget.linkedEntities[entityID] = entityName;
+      });
+    }
+    // update in database
     if (widget.parentType == "shopping list") {
-      db.updateStoreLink(widget.parentID, entityID, val);
+      db.updateStoreLink(widget.parentID, entityID, entityName, value);
     } else if (widget.parentType == "store") {
-      db.updateShoppingListLink(widget.parentID, entityID, val);
+      db.updateShoppingListLink(widget.parentID, entityID, entityName, value);
     }
   }
 
@@ -52,7 +69,7 @@ class _ToggleListState extends State<ToggleList> {
           return SwitchListTile(
             title: Text(item.name),
             value: widget.linkedEntities?.containsKey(item.id) ?? false,
-            onChanged: (bool value) => toggleItem(item.id, value),
+            onChanged: (bool value) => toggleItem(item.id, item.name, value),
           );
         }
     );

--- a/lib/components/toggle_list.dart
+++ b/lib/components/toggle_list.dart
@@ -41,6 +41,8 @@ class _ToggleListState extends State<ToggleList> {
   @override
   Widget build(BuildContext context) {
 
+    print(widget.linkedEntities);
+
     return ListView.builder(
         shrinkWrap: true, // gives it a size
         itemCount: widget.list.length,

--- a/lib/db/database_manager.dart
+++ b/lib/db/database_manager.dart
@@ -120,24 +120,14 @@ class DatabaseManager {
     }
   }
 
-  Future updateStoreLink(String parentListID, String entityID, bool val) async {
-    print("Changing $entityID to ${val.toString()}");
+  Future updateStoreLink(String parentListID, String entityID, String name, bool val) async {
     DocumentReference shoppingListRef = shoppingLists.document(parentListID);
-    shoppingListRef.setData({
-      "stores": {
-        {entityID}:{val}
-      }
-    });
+    val == true ? shoppingListRef.updateData({'stores.$entityID': name}) : shoppingListRef.updateData({'stores.$entityID': FieldValue.delete()});
   }
 
-  Future updateShoppingListLink(String parentStoreID, String entityID, bool val) async {
-    print("Changing $entityID to ${val.toString()}");
-    DocumentReference storeRef = stores.document(parentStoreID);
-    storeRef.setData({
-      "shoppingLists": {
-        {entityID}:{val}
-      }
-    });
+  Future updateShoppingListLink(String parentStoreID, String entityID, String name, bool val) async {
+    DocumentReference storeRef =  stores.document(parentStoreID);
+    val == true ? storeRef.updateData({'shoppingLists.$entityID': name}) : storeRef.updateData({'shoppingLists.$entityID': FieldValue.delete()});
   }
 
 }

--- a/lib/db/database_manager.dart
+++ b/lib/db/database_manager.dart
@@ -34,9 +34,23 @@ class DatabaseManager {
       }).catchError((e) {
         print(e.toString());
       });
+      updateLinkedStores(shoppingList.id, shoppingList.name);
     } else {
       print("ID is null/has no length");
     }
+  }
+
+  Future updateLinkedStores(shoppingListID, newName) async {
+    // update all the stores' "shopping lists" maps to use the new shopping list name
+    await stores
+        .getDocuments()
+        .then((querySnapshot) => {
+      querySnapshot.documents.forEach((doc) => {
+        if (doc.data['shoppingLists'][shoppingListID] != null) {
+          doc.reference.updateData({'shoppingLists.$shoppingListID': newName})
+        }
+      })
+    });
   }
 
   Future addItemToShoppingList(String listID, String itemID) async {

--- a/lib/db/database_manager.dart
+++ b/lib/db/database_manager.dart
@@ -120,14 +120,14 @@ class DatabaseManager {
     }
   }
 
-  Future updateStoreLink(String parentListID, String entityID, String name, bool val) async {
-    DocumentReference shoppingListRef = shoppingLists.document(parentListID);
-    val == true ? shoppingListRef.updateData({'stores.$entityID': name}) : shoppingListRef.updateData({'stores.$entityID': FieldValue.delete()});
-  }
+  Future updateStoreShoppingListLink(String shoppingListID, String storeID, String shoppingListName, String storeName, bool val) async {
+    // add this store to the specified shopping list
+    DocumentReference shoppingListRef = shoppingLists.document(shoppingListID);
+    val == true ? shoppingListRef.updateData({'stores.$storeID': storeName}) : shoppingListRef.updateData({'stores.$storeID': FieldValue.delete()});
 
-  Future updateShoppingListLink(String parentStoreID, String entityID, String name, bool val) async {
-    DocumentReference storeRef =  stores.document(parentStoreID);
-    val == true ? storeRef.updateData({'shoppingLists.$entityID': name}) : storeRef.updateData({'shoppingLists.$entityID': FieldValue.delete()});
+    // and add this shopping list to the specified store
+    DocumentReference storeRef =  stores.document(storeID);
+    val == true ? storeRef.updateData({'shoppingLists.$shoppingListID': shoppingListName}) : storeRef.updateData({'shoppingLists.$shoppingListID': FieldValue.delete()});
   }
 
 }

--- a/lib/db/database_manager.dart
+++ b/lib/db/database_manager.dart
@@ -121,6 +121,7 @@ class DatabaseManager {
   }
 
   Future updateStoreLink(String parentListID, String entityID, bool val) async {
+    print("Changing $entityID to ${val.toString()}");
     DocumentReference shoppingListRef = shoppingLists.document(parentListID);
     shoppingListRef.setData({
       "stores": {
@@ -130,6 +131,7 @@ class DatabaseManager {
   }
 
   Future updateShoppingListLink(String parentStoreID, String entityID, bool val) async {
+    print("Changing $entityID to ${val.toString()}");
     DocumentReference storeRef = stores.document(parentStoreID);
     storeRef.setData({
       "shoppingLists": {

--- a/lib/db/database_manager.dart
+++ b/lib/db/database_manager.dart
@@ -73,9 +73,23 @@ class DatabaseManager {
       }).catchError((e) {
         print(e.toString());
       });
+      updateLinkedShoppingLists(store.id, store.name + " (" + store.address + ")");
     } else {
       print("ID is null/has no length");
     }
+  }
+
+  Future updateLinkedShoppingLists(storeID, newName) async {
+    // update all the shopping lists's "stores" maps to use the new store name
+    await shoppingLists
+        .getDocuments()
+        .then((querySnapshot) => {
+          querySnapshot.documents.forEach((doc) => {
+            if (doc.data['stores'][storeID] != null) { // can't use ['stores.$storeID']
+              doc.reference.updateData({'stores.$storeID': newName})
+            }
+          })
+        });
   }
 
   Future<DocumentReference> createItem(String parentListID, ItemDTO item) async {

--- a/lib/db/database_manager.dart
+++ b/lib/db/database_manager.dart
@@ -120,4 +120,22 @@ class DatabaseManager {
     }
   }
 
+  Future updateStoreLink(String parentListID, String entityID, bool val) async {
+    DocumentReference shoppingListRef = shoppingLists.document(parentListID);
+    shoppingListRef.setData({
+      "stores": {
+        {entityID}:{val}
+      }
+    });
+  }
+
+  Future updateShoppingListLink(String parentStoreID, String entityID, bool val) async {
+    DocumentReference storeRef = stores.document(parentStoreID);
+    storeRef.setData({
+      "shoppingLists": {
+        {entityID}:{val}
+      }
+    });
+  }
+
 }

--- a/lib/db/shopping_list_dto.dart
+++ b/lib/db/shopping_list_dto.dart
@@ -4,9 +4,10 @@ class ShoppingListDTO {
   String name;
   String date;
   int itemCount;
+  Map stores;
 
   String toString() {
-    return 'id: $id, name: $name, date: $date, itemCount: $itemCount';
+    return 'id: $id, name: $name, date: $date, itemCount: $itemCount, stores: $stores';
   }
 
   Map<String, dynamic> toJson() => <String, dynamic> {
@@ -14,5 +15,6 @@ class ShoppingListDTO {
     'name': this.name ?? 'unnamed item',
     'date': this.date,
     'itemCount': this.itemCount ?? 0,
+    'stores': this.stores,
   };
 }

--- a/lib/db/store_dto.dart
+++ b/lib/db/store_dto.dart
@@ -4,9 +4,10 @@ class StoreDTO {
   String name;
   String date;
   String address;
+  Map shoppingLists;
 
   String toString() {
-    return 'id: $id, name: $name, date: $date, address: $address';
+    return 'id: $id, name: $name, date: $date, address: $address, shoppingLists: $shoppingLists';
   }
 
   Map<String, dynamic> toJson() => <String, dynamic> {
@@ -14,5 +15,6 @@ class StoreDTO {
     'name': this.name,
     'date': this.date,
     'address': this.address,
+    'shoppingLists': this.shoppingLists,
   };
 }

--- a/lib/forms/components/linked_entities_list.dart
+++ b/lib/forms/components/linked_entities_list.dart
@@ -6,7 +6,7 @@ class LinkedEntitiesList extends StatelessWidget {
   final String parentID;
   final String parentName;
   final String listType;
-  final linkedEntities;
+  final Map linkedEntities;
   final String entities;
 
   LinkedEntitiesList(this.parentID, this.listType, this.parentName, this.linkedEntities, this.entities);
@@ -30,6 +30,7 @@ class LinkedEntitiesList extends StatelessWidget {
     }
 
     var _list = linkedEntities != null ? linkedEntities.values.toList() : [];
+    print(_list);
 
     return Container(
       height:300,

--- a/lib/forms/components/linked_entities_list.dart
+++ b/lib/forms/components/linked_entities_list.dart
@@ -30,7 +30,6 @@ class LinkedEntitiesList extends StatelessWidget {
     }
 
     var _list = linkedEntities != null ? linkedEntities.values.toList() : [];
-    print(_list);
 
     return Container(
       height:300,

--- a/lib/forms/components/linked_entities_list.dart
+++ b/lib/forms/components/linked_entities_list.dart
@@ -1,14 +1,24 @@
 import 'package:flutter/material.dart';
+import 'package:grocery_go/views/manage_links.dart';
+import '../../db/database_manager.dart';
 
 class LinkedEntitiesList extends StatelessWidget {
-  final linkedEntities;
+  final String parentID;
   final String listType;
+  final linkedEntities;
   final String entities;
 
-  LinkedEntitiesList(this.linkedEntities, this.listType, this.entities);
+  LinkedEntitiesList(this.parentID, this.listType, this.linkedEntities, this.entities);
+
+  final DatabaseManager db = DatabaseManager();
 
   @override
   Widget build(BuildContext context) {
+
+    _goToManageLinks() {
+      Navigator.pushNamed(context, ManageLinks.routeName, arguments: ManageLinksArguments(dbStream: db.getStoresStream(), linkedEntities: linkedEntities, parentID: parentID, parentType: listType));
+    }
+
     var _list = linkedEntities != null ? linkedEntities.values.toList() : [];
 
     return Flexible(
@@ -17,7 +27,7 @@ class LinkedEntitiesList extends StatelessWidget {
         children: <Widget>[
           _listTitle(),
           ..._entityList(_list),
-          _manageLinksButton(),
+          _manageLinksButton(_goToManageLinks),
         ],
       ));
     }
@@ -33,9 +43,10 @@ class LinkedEntitiesList extends StatelessWidget {
     return list?.map((item) => Text(item, style: TextStyle(height: 1.6)))?.toList() ?? shortList;
   }
 
-  _manageLinksButton() {
+  _manageLinksButton(onPressedAction) {
+
     return FlatButton(
-      onPressed: () => print("pressed"),
+      onPressed: () => onPressedAction(),
       child: Text("Add/Remove $entities"),
       textColor:Colors.blue,
       padding: EdgeInsets.all(0),

--- a/lib/forms/components/linked_entities_list.dart
+++ b/lib/forms/components/linked_entities_list.dart
@@ -4,11 +4,12 @@ import '../../db/database_manager.dart';
 
 class LinkedEntitiesList extends StatelessWidget {
   final String parentID;
+  final String parentName;
   final String listType;
   final linkedEntities;
   final String entities;
 
-  LinkedEntitiesList(this.parentID, this.listType, this.linkedEntities, this.entities);
+  LinkedEntitiesList(this.parentID, this.listType, this.parentName, this.linkedEntities, this.entities);
 
   final DatabaseManager db = DatabaseManager();
 
@@ -25,12 +26,13 @@ class LinkedEntitiesList extends StatelessWidget {
         print("Error: unrecognized list type in linked_entities_list.dart");
       }
 
-      Navigator.pushNamed(context, ManageLinks.routeName, arguments: ManageLinksArguments(dbStream: stream, linkedEntities: linkedEntities, parentID: parentID, parentType: listType));
+      Navigator.pushNamed(context, ManageLinks.routeName, arguments: ManageLinksArguments(dbStream: stream, linkedEntities: linkedEntities, parentID: parentID, parentName: parentName, parentType: listType));
     }
 
     var _list = linkedEntities != null ? linkedEntities.values.toList() : [];
 
-    return Flexible(
+    return Container(
+      height:300,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
@@ -46,10 +48,21 @@ class LinkedEntitiesList extends StatelessWidget {
   }
 
   _entityList(list) {
-    var shortList = List();
-    shortList.add(Text("This $listType is not attached to any $entities yet."));
-    // if 'list' is empty, default to shortList which is guaranteed to have something
-    return list?.map((item) => Text(item.toString(), style: TextStyle(height: 1.6)))?.toList() ?? shortList;
+    const MAX_LIST_LEN = 4;
+
+    if (list == null || list?.length == 0) {
+      return [Text("This $listType is not attached to any $entities yet.")];
+    } else {
+      var listLen = list.length > MAX_LIST_LEN ? MAX_LIST_LEN : list.length;
+      var entityList = List();
+      for (var i = 0; i < listLen; i++) {
+        entityList.add(Text(list[i].toString()));
+      }
+      if (list.length > MAX_LIST_LEN) {
+        entityList.add(Text('+${list.length - MAX_LIST_LEN} more'));
+      }
+      return entityList;
+    }
   }
 
   _manageLinksButton(onPressedAction) {

--- a/lib/forms/components/linked_entities_list.dart
+++ b/lib/forms/components/linked_entities_list.dart
@@ -16,7 +16,16 @@ class LinkedEntitiesList extends StatelessWidget {
   Widget build(BuildContext context) {
 
     _goToManageLinks() {
-      Navigator.pushNamed(context, ManageLinks.routeName, arguments: ManageLinksArguments(dbStream: db.getStoresStream(), linkedEntities: linkedEntities, parentID: parentID, parentType: listType));
+      var stream;
+      if (listType == "shopping list") {
+        stream = db.getStoresStream();
+      } else if (listType == "store") {
+        stream = db.getShoppingListStream();
+      } else {
+        print("Error: unrecognized list type in linked_entities_list.dart");
+      }
+
+      Navigator.pushNamed(context, ManageLinks.routeName, arguments: ManageLinksArguments(dbStream: stream, linkedEntities: linkedEntities, parentID: parentID, parentType: listType));
     }
 
     var _list = linkedEntities != null ? linkedEntities.values.toList() : [];

--- a/lib/forms/components/linked_entities_list.dart
+++ b/lib/forms/components/linked_entities_list.dart
@@ -49,7 +49,7 @@ class LinkedEntitiesList extends StatelessWidget {
     var shortList = List();
     shortList.add(Text("This $listType is not attached to any $entities yet."));
     // if 'list' is empty, default to shortList which is guaranteed to have something
-    return list?.map((item) => Text(item, style: TextStyle(height: 1.6)))?.toList() ?? shortList;
+    return list?.map((item) => Text(item.toString(), style: TextStyle(height: 1.6)))?.toList() ?? shortList;
   }
 
   _manageLinksButton(onPressedAction) {

--- a/lib/forms/edit_item_form.dart
+++ b/lib/forms/edit_item_form.dart
@@ -80,7 +80,6 @@ class _EditItemFormState extends State<EditItemForm> {
 
   @override
   void initState() {
-    print(args.item.date.toString());
     itemFields.id = args.item.id;
     itemFields.name = args.item.name;
     itemFields.addedBy = args.item.addedBy;

--- a/lib/forms/new_item_form.dart
+++ b/lib/forms/new_item_form.dart
@@ -30,8 +30,6 @@ class _NewItemFormState extends State<NewItemForm> {
   void saveItem(BuildContext context) async {
     final formState = formKey.currentState;
 
-    print(args);
-
     if (formState.validate()) {
       formKey.currentState.save();
 

--- a/lib/forms/shopping_list_form.dart
+++ b/lib/forms/shopping_list_form.dart
@@ -40,6 +40,7 @@ class _ShoppingListFormState extends State<ShoppingListForm> {
         shoppingListFields.id = widget.shoppingList.id;
         await db.updateShoppingList(widget.shoppingList.id, shoppingListFields);
       } else {
+        shoppingListFields.stores = Map();
         await db.addShoppingList(shoppingListFields);
       }
 
@@ -71,7 +72,7 @@ class _ShoppingListFormState extends State<ShoppingListForm> {
       fields.add(_linkedEntities());
     }
 
-    return Expanded(
+    return Container(
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: fields,
@@ -99,7 +100,7 @@ class _ShoppingListFormState extends State<ShoppingListForm> {
 
   _linkedEntities() {
     return LinkedEntitiesList(
-        widget.shoppingList.id, "shopping list", widget.shoppingList.stores, "Stores");
+        widget.shoppingList.id, "shopping list", widget.shoppingList.name, widget.shoppingList.stores, "Stores");
   }
 
   _saveButton() {

--- a/lib/forms/shopping_list_form.dart
+++ b/lib/forms/shopping_list_form.dart
@@ -1,21 +1,21 @@
 import 'package:flutter/material.dart';
-import 'package:grocery_go/components/linked_entities_list.dart';
+import 'package:grocery_go/forms/components/linked_entities_list.dart';
 import 'package:grocery_go/db/database_manager.dart';
 import 'package:grocery_go/db/shopping_list_dto.dart';
+import 'package:grocery_go/models/shopping_list.dart';
 
 class ShoppingListForm extends StatefulWidget {
-  final args;
+  final ShoppingList shoppingList; // see model for full list of properties
 
-  ShoppingListForm({this.args});
+  ShoppingListForm({this.shoppingList});
 
   @override
-  _ShoppingListFormState createState() => _ShoppingListFormState(args);
+  _ShoppingListFormState createState() => _ShoppingListFormState();
 }
 
 class _ShoppingListFormState extends State<ShoppingListForm> {
 
-  final args;
-  _ShoppingListFormState(this.args);
+  _ShoppingListFormState();
 
   final formKey = GlobalKey<FormState>();
   final DatabaseManager db = DatabaseManager();
@@ -35,10 +35,10 @@ class _ShoppingListFormState extends State<ShoppingListForm> {
       formKey.currentState.save();
       shoppingListFields.date = DateTime.now().toString();
 
-      if (args != null) {
+      if (widget.shoppingList != null) {
         // preserve existing data from args
-        shoppingListFields.id = args.list.id;
-        await db.updateShoppingList(args.list.id, shoppingListFields);
+        shoppingListFields.id = widget.shoppingList.id;
+        await db.updateShoppingList(widget.shoppingList.id, shoppingListFields);
       } else {
         await db.addShoppingList(shoppingListFields);
       }
@@ -73,7 +73,7 @@ class _ShoppingListFormState extends State<ShoppingListForm> {
             padding: EdgeInsets.fromLTRB(0, 0, 0, 10),
             child: TextFormField(
                 autofocus: true,
-                initialValue: (args?.list?.name),
+                initialValue: (widget.shoppingList.name),
                 decoration: InputDecoration(
                     labelText: 'List name',
                     border: OutlineInputBorder()
@@ -84,7 +84,7 @@ class _ShoppingListFormState extends State<ShoppingListForm> {
                 }
             ),
           ),
-          LinkedEntitiesList(args?.list?.stores, "shopping list", "Stores"),
+          LinkedEntitiesList(widget.shoppingList.id, "shopping list", widget.shoppingList.stores, "Stores"),
         ],
       ),
     );

--- a/lib/forms/shopping_list_form.dart
+++ b/lib/forms/shopping_list_form.dart
@@ -52,10 +52,25 @@ class _ShoppingListFormState extends State<ShoppingListForm> {
 
     return Form(
       key: formKey,
+      child: Padding(
+        padding: EdgeInsets.all(8.0),
+        child: Column(
+          children: [
+            _formFields(),
+            _saveButton(),
+          ],
+        ),
+      ),
+    );
+  }
+
+  _formFields() {
+    return Expanded(
       child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Padding(
-            padding: EdgeInsets.all(8.0),
+            padding: EdgeInsets.fromLTRB(0, 0, 0, 10),
             child: TextFormField(
                 autofocus: true,
                 initialValue: (args?.list?.name),
@@ -70,11 +85,21 @@ class _ShoppingListFormState extends State<ShoppingListForm> {
             ),
           ),
           LinkedEntitiesList(args?.list?.stores, "shopping list", "Stores"),
+        ],
+      ),
+    );
+  }
+
+  _saveButton() {
+    return Expanded(
+        child: Column(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
           RaisedButton(
             onPressed: () => updateShoppingList(context),
             child: Text('Save shopping list'),
           ),
-        ],
+        ]
       ),
     );
   }

--- a/lib/forms/shopping_list_form.dart
+++ b/lib/forms/shopping_list_form.dart
@@ -65,29 +65,40 @@ class _ShoppingListFormState extends State<ShoppingListForm> {
   }
 
   _formFields() {
+    List<Widget> fields = [_nameField()];
+    if (widget.shoppingList?.id != null) {
+      fields.add(_linkedEntities());
+    }
+
     return Expanded(
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Padding(
-            padding: EdgeInsets.fromLTRB(0, 0, 0, 10),
-            child: TextFormField(
-                autofocus: true,
-                initialValue: (widget.shoppingList.name),
-                decoration: InputDecoration(
-                    labelText: 'List name',
-                    border: OutlineInputBorder()
-                ),
-                validator: (value) => validateStringInput(value),
-                onSaved: (value) {
-                  shoppingListFields.name = value;
-                }
-            ),
-          ),
-          LinkedEntitiesList(widget.shoppingList.id, "shopping list", widget.shoppingList.stores, "Stores"),
-        ],
+        children: fields,
       ),
     );
+  }
+
+  _nameField() {
+    return Padding(
+      padding: EdgeInsets.fromLTRB(0, 0, 0, 10),
+      child: TextFormField(
+          autofocus: true,
+          initialValue: widget.shoppingList?.name ?? '',
+          decoration: InputDecoration(
+              labelText: 'List name',
+              border: OutlineInputBorder()
+          ),
+          validator: (value) => validateStringInput(value),
+          onSaved: (value) {
+            shoppingListFields.name = value;
+          }
+      ),
+    );
+  }
+
+  _linkedEntities() {
+    return LinkedEntitiesList(
+        widget.shoppingList.id, "shopping list", widget.shoppingList.stores, "Stores");
   }
 
   _saveButton() {

--- a/lib/forms/shopping_list_form.dart
+++ b/lib/forms/shopping_list_form.dart
@@ -38,6 +38,7 @@ class _ShoppingListFormState extends State<ShoppingListForm> {
       if (widget.shoppingList != null) {
         // preserve existing data from args
         shoppingListFields.id = widget.shoppingList.id;
+        shoppingListFields.stores = widget.shoppingList.stores;
         await db.updateShoppingList(widget.shoppingList.id, shoppingListFields);
       } else {
         shoppingListFields.stores = Map();

--- a/lib/forms/shopping_list_form.dart
+++ b/lib/forms/shopping_list_form.dart
@@ -66,6 +66,7 @@ class _ShoppingListFormState extends State<ShoppingListForm> {
 
   _formFields() {
     List<Widget> fields = [_nameField()];
+    // if we're editing an existing shopping list, add the linked stores
     if (widget.shoppingList?.id != null) {
       fields.add(_linkedEntities());
     }

--- a/lib/forms/shopping_list_form.dart
+++ b/lib/forms/shopping_list_form.dart
@@ -69,7 +69,7 @@ class _ShoppingListFormState extends State<ShoppingListForm> {
                 }
             ),
           ),
-          LinkedEntitiesList(args?.list?.stores),
+          LinkedEntitiesList(args?.list?.stores, "shopping list", "Stores"),
           RaisedButton(
             onPressed: () => updateShoppingList(context),
             child: Text('Save shopping list'),

--- a/lib/forms/shopping_list_form.dart
+++ b/lib/forms/shopping_list_form.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:grocery_go/components/linked_entities_list.dart';
 import 'package:grocery_go/db/database_manager.dart';
 import 'package:grocery_go/db/shopping_list_dto.dart';
 
@@ -68,6 +69,7 @@ class _ShoppingListFormState extends State<ShoppingListForm> {
                 }
             ),
           ),
+          LinkedEntitiesList(args?.list?.stores),
           RaisedButton(
             onPressed: () => updateShoppingList(context),
             child: Text('Save shopping list'),

--- a/lib/forms/store_form.dart
+++ b/lib/forms/store_form.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:grocery_go/components/linked_entities_list.dart';
 import 'package:grocery_go/db/database_manager.dart';
 import 'package:grocery_go/db/store_dto.dart';
 
@@ -69,17 +70,21 @@ class _StoreFormState extends State<StoreForm> {
           ),
           Padding(
             padding: EdgeInsets.all(8.0),
-            child: TextFormField(
-                autofocus: false,
-                initialValue: (args?.store?.address),
-                decoration: InputDecoration(
-                    labelText: 'Location (optional)',
-                    border: OutlineInputBorder()
+            child: Column(
+              children: [
+                TextFormField(
+                  autofocus: false,
+                  initialValue: (args?.store?.address),
+                  decoration: InputDecoration(
+                      labelText: 'Location (optional)',
+                      border: OutlineInputBorder()
+                  ),
+                  validator: (value) => validateStringInput(value),
+                  onSaved: (value) {
+                    storeFields.address = value;
+                  }
                 ),
-                validator: (value) => validateStringInput(value),
-                onSaved: (value) {
-                  storeFields.address = value;
-                }
+              ],
             ),
           ),
           RaisedButton(

--- a/lib/forms/store_form.dart
+++ b/lib/forms/store_form.dart
@@ -51,10 +51,25 @@ class _StoreFormState extends State<StoreForm> {
 
     return Form(
       key: formKey,
+      child: Padding(
+        padding: EdgeInsets.all(8.0),
+        child: Column(
+          children: [
+            _formFields(),
+            _saveButton(),
+          ]
+        )
+      )
+    );
+  }
+
+  _formFields() {
+    return Expanded(
       child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Padding(
-            padding: EdgeInsets.all(8.0),
+            padding: EdgeInsets.fromLTRB(0, 0, 0, 10),
             child: TextFormField(
                 autofocus: true,
                 initialValue: (args?.store?.name),
@@ -69,29 +84,40 @@ class _StoreFormState extends State<StoreForm> {
             ),
           ),
           Padding(
-            padding: EdgeInsets.all(8.0),
+            padding: EdgeInsets.fromLTRB(0, 0, 0, 10),
             child: Column(
               children: [
                 TextFormField(
-                  autofocus: false,
-                  initialValue: (args?.store?.address),
-                  decoration: InputDecoration(
-                      labelText: 'Location (optional)',
-                      border: OutlineInputBorder()
-                  ),
-                  validator: (value) => validateStringInput(value),
-                  onSaved: (value) {
-                    storeFields.address = value;
-                  }
+                    autofocus: false,
+                    initialValue: (args?.store?.address),
+                    decoration: InputDecoration(
+                        labelText: 'Location (optional)',
+                        border: OutlineInputBorder()
+                    ),
+                    validator: (value) => validateStringInput(value),
+                    onSaved: (value) {
+                      storeFields.address = value;
+                    }
                 ),
               ],
             ),
           ),
+          LinkedEntitiesList(args?.store?.shoppingLists, "store", "Shopping Lists"),
+        ],
+      ),
+    );
+  }
+
+  _saveButton() {
+    return Expanded(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
           RaisedButton(
             onPressed: () => updateStore(context),
             child: Text('Save store'),
           ),
-        ],
+        ]
       ),
     );
   }

--- a/lib/forms/store_form.dart
+++ b/lib/forms/store_form.dart
@@ -65,6 +65,7 @@ class _StoreFormState extends State<StoreForm> {
 
   _formFields() {
     List<Widget> fields = [_nameField(), _addressField()];
+    // if we're editing an existing store, add the linked shopping lists
     if (widget.store?.id != null) {
       fields.add(_linkedEntities());
     }

--- a/lib/forms/store_form.dart
+++ b/lib/forms/store_form.dart
@@ -1,21 +1,21 @@
 import 'package:flutter/material.dart';
-import 'package:grocery_go/components/linked_entities_list.dart';
+import 'package:grocery_go/forms/components/linked_entities_list.dart';
 import 'package:grocery_go/db/database_manager.dart';
 import 'package:grocery_go/db/store_dto.dart';
+import 'package:grocery_go/models/store.dart';
 
 class StoreForm extends StatefulWidget {
-  final args;
+  final Store store;
 
-  StoreForm({this.args});
+  StoreForm({this.store});
 
   @override
-  _StoreFormState createState() => _StoreFormState(args);
+  _StoreFormState createState() => _StoreFormState();
 }
 
 class _StoreFormState extends State<StoreForm> {
 
-  final args;
-  _StoreFormState(this.args);
+  _StoreFormState();
 
   final formKey = GlobalKey<FormState>();
   final DatabaseManager db = DatabaseManager();
@@ -35,9 +35,9 @@ class _StoreFormState extends State<StoreForm> {
       formKey.currentState.save();
       storeFields.date = DateTime.now().toString();
 
-      if (args != null) {
-        storeFields.id = args.store.id;
-        await db.updateStore(args.store.id, storeFields);
+      if (widget.store != null) {
+        storeFields.id = widget.store.id;
+        await db.updateStore(widget.store.id, storeFields);
       } else {
         await db.addStore(storeFields);
       }
@@ -72,7 +72,7 @@ class _StoreFormState extends State<StoreForm> {
             padding: EdgeInsets.fromLTRB(0, 0, 0, 10),
             child: TextFormField(
                 autofocus: true,
-                initialValue: (args?.store?.name),
+                initialValue: (widget.store.name),
                 decoration: InputDecoration(
                     labelText: 'Store name',
                     border: OutlineInputBorder()
@@ -89,7 +89,7 @@ class _StoreFormState extends State<StoreForm> {
               children: [
                 TextFormField(
                     autofocus: false,
-                    initialValue: (args?.store?.address),
+                    initialValue: (widget.store.address),
                     decoration: InputDecoration(
                         labelText: 'Location (optional)',
                         border: OutlineInputBorder()
@@ -102,7 +102,7 @@ class _StoreFormState extends State<StoreForm> {
               ],
             ),
           ),
-          LinkedEntitiesList(args?.store?.shoppingLists, "store", "Shopping Lists"),
+          LinkedEntitiesList(widget.store.id, "store", widget.store.shoppingLists, "Shopping Lists"),
         ],
       ),
     );

--- a/lib/forms/store_form.dart
+++ b/lib/forms/store_form.dart
@@ -39,6 +39,7 @@ class _StoreFormState extends State<StoreForm> {
         storeFields.id = widget.store.id;
         await db.updateStore(widget.store.id, storeFields);
       } else {
+        storeFields.shoppingLists = Map();
         await db.addStore(storeFields);
       }
 
@@ -70,7 +71,7 @@ class _StoreFormState extends State<StoreForm> {
       fields.add(_linkedEntities());
     }
 
-    return Expanded(
+    return Container(
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: fields,
@@ -120,7 +121,7 @@ class _StoreFormState extends State<StoreForm> {
 
   _linkedEntities() {
     return LinkedEntitiesList(
-        widget.store.id, "store", widget.store.shoppingLists, "Shopping Lists");
+        widget.store.id, "store", widget.store.name, widget.store.shoppingLists, "Shopping Lists");
   }
 
   _saveButton() {

--- a/lib/forms/store_form.dart
+++ b/lib/forms/store_form.dart
@@ -37,6 +37,7 @@ class _StoreFormState extends State<StoreForm> {
 
       if (widget.store != null) {
         storeFields.id = widget.store.id;
+        storeFields.shoppingLists = widget.store.shoppingLists;
         await db.updateStore(widget.store.id, storeFields);
       } else {
         storeFields.shoppingLists = Map();

--- a/lib/forms/store_form.dart
+++ b/lib/forms/store_form.dart
@@ -64,48 +64,62 @@ class _StoreFormState extends State<StoreForm> {
   }
 
   _formFields() {
+    List<Widget> fields = [_nameField(), _addressField()];
+    if (widget.store?.id != null) {
+      fields.add(_linkedEntities());
+    }
+
     return Expanded(
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
+        children: fields,
+      ),
+    );
+  }
+
+  _nameField() {
+    return Padding(
+      padding: EdgeInsets.fromLTRB(0, 0, 0, 10),
+      child: TextFormField(
+          autofocus: true,
+          initialValue: widget.store?.name ?? '',
+          decoration: InputDecoration(
+              labelText: 'Store name',
+              border: OutlineInputBorder()
+          ),
+          validator: (value) => validateStringInput(value),
+          onSaved: (value) {
+            storeFields.name = value;
+          }
+      ),
+    );
+  }
+
+  _addressField() {
+    return Padding(
+      padding: EdgeInsets.fromLTRB(0, 0, 0, 10),
+      child: Column(
         children: [
-          Padding(
-            padding: EdgeInsets.fromLTRB(0, 0, 0, 10),
-            child: TextFormField(
-                autofocus: true,
-                initialValue: (widget.store.name),
-                decoration: InputDecoration(
-                    labelText: 'Store name',
-                    border: OutlineInputBorder()
-                ),
-                validator: (value) => validateStringInput(value),
-                onSaved: (value) {
-                  storeFields.name = value;
-                }
-            ),
+          TextFormField(
+              autofocus: false,
+              initialValue: widget.store?.address ?? '',
+              decoration: InputDecoration(
+                  labelText: 'Location (optional)',
+                  border: OutlineInputBorder()
+              ),
+              validator: (value) => validateStringInput(value),
+              onSaved: (value) {
+                storeFields.address = value;
+              }
           ),
-          Padding(
-            padding: EdgeInsets.fromLTRB(0, 0, 0, 10),
-            child: Column(
-              children: [
-                TextFormField(
-                    autofocus: false,
-                    initialValue: (widget.store.address),
-                    decoration: InputDecoration(
-                        labelText: 'Location (optional)',
-                        border: OutlineInputBorder()
-                    ),
-                    validator: (value) => validateStringInput(value),
-                    onSaved: (value) {
-                      storeFields.address = value;
-                    }
-                ),
-              ],
-            ),
-          ),
-          LinkedEntitiesList(widget.store.id, "store", widget.store.shoppingLists, "Shopping Lists"),
         ],
       ),
     );
+  }
+
+  _linkedEntities() {
+    return LinkedEntitiesList(
+        widget.store.id, "store", widget.store.shoppingLists, "Shopping Lists");
   }
 
   _saveButton() {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:grocery_go/components/item_list_stream.dart';
 import 'package:grocery_go/views/existing_list.dart';
+import 'package:grocery_go/views/manage_links.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import './components/item_list_header.dart';
@@ -14,6 +15,7 @@ import './views/new_item.dart';
 import './views/new_shopping_list.dart';
 import './views/new_store.dart';
 import './views/edit_item.dart';
+import './views/manage_links.dart';
 
 import './db/database_manager.dart';
 
@@ -51,6 +53,7 @@ class _GroceryGoAppState extends State<GroceryGoApp> {
       NewStore.routeName: (context) => NewStore(),
       NewItem.routeName: (context) => NewItem(),
       ExistingItem.routeName: (context) => ExistingItem(),
+      ManageLinks.routeName: (context) => ManageLinks(),
     };
 
     return MaterialApp(

--- a/lib/models/shopping_list.dart
+++ b/lib/models/shopping_list.dart
@@ -6,11 +6,13 @@ class ShoppingList {
   String listType = 'shopping list';
   String date;
   int itemCount;
+  Map stores;
 
   ShoppingList(DocumentSnapshot document) {
     this.id = document['id'];
     this.name = document['name'];
     this.date = document['date'];
     this.itemCount = document['itemCount'];
+    this.stores = document['stores'];
   }
 }

--- a/lib/models/store.dart
+++ b/lib/models/store.dart
@@ -4,10 +4,12 @@ class Store {
   String id;
   String name;
   String address;
+  Map shoppingLists;
 
   Store(DocumentSnapshot document) {
     this.id = document['id'];
     this.name = document['name'];
     this.address = document['address'];
+    this.shoppingLists = document['stores'];
   }
 }

--- a/lib/models/store.dart
+++ b/lib/models/store.dart
@@ -10,6 +10,6 @@ class Store {
     this.id = document['id'];
     this.name = document['name'];
     this.address = document['address'];
-    this.shoppingLists = document['stores'];
+    this.shoppingLists = document['shoppingLists'];
   }
 }

--- a/lib/views/existing_list.dart
+++ b/lib/views/existing_list.dart
@@ -4,6 +4,7 @@ import 'package:grocery_go/models/shopping_list.dart';
 
 class ExistingListArguments {
   final ShoppingList list;
+
   ExistingListArguments(this.list);
 }
 
@@ -28,7 +29,7 @@ class _ExistingListState extends State<ExistingList> {
       body: Center(
         child: Padding(
           padding: EdgeInsets.all(20),
-          child: ShoppingListForm(args: args),
+          child: ShoppingListForm(shoppingList: args.list),
         ),
       ),
     );

--- a/lib/views/existing_store.dart
+++ b/lib/views/existing_store.dart
@@ -29,7 +29,7 @@ class _ExistingStoreState extends State<ExistingStore> {
       body: Center(
         child: Padding(
           padding: EdgeInsets.all(20),
-          child: StoreForm(args: args),
+          child: StoreForm(store: args.store),
         ),
       ),
     );

--- a/lib/views/manage_links.dart
+++ b/lib/views/manage_links.dart
@@ -5,9 +5,10 @@ class ManageLinksArguments {
   final dbStream;
   final linkedEntities;
   final String parentID;
+  final String parentName;
   final String parentType;
 
-  ManageLinksArguments({this.dbStream, this.linkedEntities, this.parentID, this.parentType});
+  ManageLinksArguments({this.dbStream, this.linkedEntities, this.parentID, this.parentName, this.parentType});
 }
 
 class ManageLinks extends StatefulWidget {
@@ -42,7 +43,7 @@ class _ManageLinks extends State<ManageLinks> {
                   return Text('Error: ${snapshot.error}');
                 }
                 if (snapshot.hasData && !snapshot.data.documents.isEmpty) {
-                  return ToggleList(parentType: args.parentType, parentID: args.parentID, list: snapshot.data.documents, linkedEntities: args.linkedEntities);
+                  return ToggleList(parentType: args.parentType, parentID: args.parentID, parentName: args.parentName, list: snapshot.data.documents, linkedEntities: args.linkedEntities);
                 } else {
                   return Column(
                     children: [

--- a/lib/views/manage_links.dart
+++ b/lib/views/manage_links.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+import 'package:grocery_go/components/toggle_list.dart';
+
+class ManageLinksArguments {
+  final dbStream;
+  final linkedEntities;
+  final String parentID;
+  final String parentType;
+
+  ManageLinksArguments({this.dbStream, this.linkedEntities, this.parentID, this.parentType});
+}
+
+class ManageLinks extends StatefulWidget {
+
+  static const routeName = '/manageLinks';
+
+  ManageLinks({Key key});
+
+  @override
+  _ManageLinks createState() => _ManageLinks();
+}
+
+class _ManageLinks extends State<ManageLinks> {
+
+  @override
+  Widget build(BuildContext context) {
+
+    final ManageLinksArguments args = ModalRoute.of(context).settings.arguments;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text("Add/Remove"),
+      ),
+      body: SingleChildScrollView(
+        child: Center(
+          child: Padding(
+            padding: EdgeInsets.all(20),
+            child: StreamBuilder(
+              stream: args.dbStream,
+              builder: (context, snapshot) {
+                if (snapshot.hasError) {
+                  return Text('Error: ${snapshot.error}');
+                }
+                if (snapshot.hasData && !snapshot.data.documents.isEmpty) {
+                  return ToggleList(parentType: args.parentType, parentID: args.parentID, list: snapshot.data.documents, linkedEntities: args.linkedEntities);
+                } else {
+                  return Column(
+                    children: [
+                      Padding(
+                        padding: EdgeInsets.all(8),
+                        child: Text("No entities yet!"),
+                      ),
+                    ],
+                  );
+                }
+              }
+            )
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ description: A new Flutter project.
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: ">=2.2.2 <3.0.0"
 
 dependencies:
   intl: ^0.16.1


### PR DESCRIPTION
- Added a new view that lets the user toggle stores "on/off" for shopping lists (and shopping lists "on/off" for stores)
- Wrote new Database Manager methods to create/delete a two-way link between stores and shopping lists whenever one is added or removed
- Added a map to the store documents (and a map to the shopping list documents) that tracks the IDs and names of any linked entities
- Made it so that changing the name of a store or shopping list also updates its name in any documents that have it in their linked entities map
- Updated the store form and shopping list forms to display a list of linked entities, with special handling for cases where there are more than 4 linked entities 